### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Stable structures are able to work directly in stable memory because each data s
 its own memory.
 When initializing a stable structure, a memory is provided that the data structure can use to store its data.
 
-Here's a basic examples:
+Here's a basic example:
 
 ### Example: BTreeMap
 

--- a/src/vec/tests.rs
+++ b/src/vec/tests.rs
@@ -249,8 +249,8 @@ fn test_iter_count() {
     }
 }
 
-// A struct with a bugg implementation of storable where the max_size can
-// smaller than the serialized size.
+// A struct with a buggy implementation of `Storable` where the max_size can
+// be smaller than the serialized size.
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq)]
 struct BuggyStruct(Vec<u8>);
 impl crate::Storable for BuggyStruct {


### PR DESCRIPTION
## Summary
- fix README grammar
- fix typo in StableVec tests comment

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt not installed)*
- `cargo test` *(fails: couldn't fetch index)*
- `cargo check` *(fails: couldn't fetch index)*

------
https://chatgpt.com/codex/tasks/task_e_6874b6012894832d978fa3bbad9b9f68