### PR TITLE
docs: fix typos in schema upgrade and security

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ DFINITY takes the security of our software products seriously, which includes al
 ## How to report a vulnerability
 
 We appreciate your help in keeping our projects secure.
-If you believe you have found a security vulnerability in any of our repositories, please report it resonsibly to us as described below:
+If you believe you have found a security vulnerability in any of our repositories, please report it responsibly to us as described below:
 
 1. **Do not disclose the vulnerability publicly.** Public disclosure could be exploited by attackers before it can be fixed.
 2. **Send an email to securitybugs@dfinity.org.** Please include the following information in your email:

--- a/docs/src/schema-upgrades.md
+++ b/docs/src/schema-upgrades.md
@@ -32,7 +32,7 @@ impl Storable for Asset {
 }
 ```
 
-> **Note:** Stables structures do not enforce a specific data format.
+> **Note:** Stable structures do not enforce a specific data format.
 It's up to the developer to use the data format that fits their use-case.
 In this example, CBOR is used for encoding `Asset`.
 


### PR DESCRIPTION
## Summary
- fix typo in schema upgrades note
- fix typo in security policy

## Testing
- `cargo test --quiet` *(fails: could not download file)*

------
https://chatgpt.com/codex/tasks/task_e_687662bf4ed4832dbf8f58ecc09628ef